### PR TITLE
Fixed duplicate interfaces, improved InterfaceTest case 

### DIFF
--- a/src/main/java/net/engio/mbassy/common/ReflectionUtils.java
+++ b/src/main/java/net/engio/mbassy/common/ReflectionUtils.java
@@ -2,6 +2,7 @@ package net.engio.mbassy.common;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -61,7 +62,7 @@ public class ReflectionUtils {
     }
 
     public static Collection<Class> getSuperclasses(Class from) {
-        Collection<Class> superclasses = new LinkedList<Class>();
+        Collection<Class> superclasses = new HashSet<Class>();
         while (!from.equals(Object.class) && !from.isInterface()) {
             superclasses.add(from.getSuperclass());
             collectInterfaces(from, superclasses);

--- a/src/test/java/net/engio/mbassy/InterfaceTest.java
+++ b/src/test/java/net/engio/mbassy/InterfaceTest.java
@@ -71,5 +71,5 @@ public class InterfaceTest {
 		Assert.fail("This class should handle this message appropriately!");
 	}
 	
-	public static class CloneMessage extends TestMessage3 implements Cloneable { }
+	public static class CloneMessage extends TestMessage3 implements Cloneable, ITestMessage { }
 }


### PR DESCRIPTION
Your commit earlier was correct, but you broke it when you merged my incorrect fix. This pull request fixes that inadvertent problem, and greatly improves `InterfaceTest.java` to search for duplicates and additional cases.
