### PR TITLE
Changed Publication Error to use system independent newline

### DIFF
--- a/src/main/java/net/engio/mbassy/PublicationError.java
+++ b/src/main/java/net/engio/mbassy/PublicationError.java
@@ -109,16 +109,17 @@ public class PublicationError {
      */
     @Override
     public String toString() {
+    	String newLine = System.getProperty("line.separator");
         return "PublicationError{" +
-                "\n" +
+                newLine +
                 "\tcause=" + cause +
-                "\n" +
+                newLine +
                 "\tmessage='" + message + '\'' +
-                "\n" +
+                newLine +
                 "\tlistener=" + listener +
-                "\n" +
+                newLine +
                 "\tlisteningObject=" + listeningObject +
-                "\n" +
+                newLine +
                 "\tpublishedObject=" + publishedObject +
                 '}';
     }


### PR DESCRIPTION
Previously the string just used "\n". Now it makes a message that is appropriate for Windows environments. Compatible with Java 6.
