### PR TITLE
Added interfaces that represent MBassador and MessagePublication.

### DIFF
--- a/src/main/java/net/engio/mbassy/bus/AbstractSyncMessageBus.java
+++ b/src/main/java/net/engio/mbassy/bus/AbstractSyncMessageBus.java
@@ -20,15 +20,12 @@ import java.util.*;
  * @param <P>
  */
 public abstract class AbstractSyncMessageBus<T, P extends ISyncMessageBus.ISyncPostCommand> implements ISyncMessageBus<T, P> {
-
-
     // this handler will receive all errors that occur during message dispatch or message handling
     private final List<IPublicationErrorHandler> errorHandlers = new ArrayList<IPublicationErrorHandler>();
 
     private final MessagePublication.Factory publicationFactory;
 
     private final SubscriptionManager subscriptionManager;
-
 
     public AbstractSyncMessageBus(SyncBusConfiguration configuration) {
         this.subscriptionManager = new SubscriptionManager(configuration.getMetadataReader(),
@@ -61,7 +58,6 @@ public abstract class AbstractSyncMessageBus<T, P extends ISyncMessageBus.ISyncP
         }
     }
 
-
     protected MessagePublication createMessagePublication(T message) {
         Collection<Subscription> subscriptions = getSubscriptionsByMessageType(message.getClass());
         if ((subscriptions == null || subscriptions.isEmpty()) && !message.getClass().equals(DeadMessage.class)) {
@@ -79,11 +75,9 @@ public abstract class AbstractSyncMessageBus<T, P extends ISyncMessageBus.ISyncP
         return subscriptionManager.getSubscriptionsByMessageType(messageType);
     }
 
-
-    public void handlePublicationError(PublicationError error) {
+    protected void handlePublicationError(PublicationError error) {
         for (IPublicationErrorHandler errorHandler : errorHandlers) {
             errorHandler.handleError(error);
         }
     }
-
 }

--- a/src/main/java/net/engio/mbassy/bus/IMBassador.java
+++ b/src/main/java/net/engio/mbassy/bus/IMBassador.java
@@ -1,0 +1,34 @@
+package net.engio.mbassy.bus;
+
+import java.util.concurrent.TimeUnit;
+
+import net.engio.mbassy.PublicationError;
+
+/**
+*
+*
+* @author durron597
+*         Date: 8/15/13
+*/
+public interface IMBassador<T, P extends IMessageBus.IPostCommand> extends IMessageBus<T, P> {
+	/**
+	 * Publish a message asynchronously. The returned {@link IMessagePublication}
+	 * has information that indicates the state of this newly published message.
+	 * 
+	 * @param message the message to be published
+	 * @return the IMessagePublication that represents this asynchronous dispatch.
+	 */
+	IMessagePublication publishAsync(T message);
+	
+	/**
+	 * Publish a message asynchronously. The returned {@link IMessagePublication}
+	 * has information that indicates the state of this newly published message.
+	 * The message dispatch will fail if it takes longer than the given timeout.
+	 * 
+	 * @param message the message to be published
+	 * @param timeout the maximum time to wait
+	 * @param unit the time unit of the timeout argument
+	 * @return the IMessagePublication that represents this asynchronous dispatch.
+	 */
+	IMessagePublication publishAsync(T message, long timeout, TimeUnit unit);
+}

--- a/src/main/java/net/engio/mbassy/bus/IMessagePublication.java
+++ b/src/main/java/net/engio/mbassy/bus/IMessagePublication.java
@@ -1,0 +1,88 @@
+package net.engio.mbassy.bus;
+
+import net.engio.mbassy.subscription.Subscription;
+
+/**
+*
+*
+* @author durron597
+*         Date: 8/15/13
+*/
+public interface IMessagePublication {
+	/**
+	 * Add a {@link net.engio.mbassy.dispatch.Subscription} to this IMessagePublication
+	 * 
+	 * @param subscription
+	 * @return true if the {@link net.engio.mbassy.dispatch.Subscription} was added successfully
+	 */
+	boolean add(Subscription subscription);
+	
+	/**
+	 * Defines whether this publication has finished 
+	 * 
+	 * @return true if this publication has finished
+	 */
+	boolean isFinished();
+	
+	/**
+	 * Defines whether this publication is running
+	 * 
+	 * @return true if this publication is running
+	 */
+	boolean isRunning();
+	
+	/**
+	 * Defines whether this publication is still scheduled
+	 * 
+	 * @return true if this publication is still scheduled
+	 */
+	boolean isScheduled();
+	
+	/**
+	 * Defines whether this publication is still scheduled
+	 * 
+	 * @return true if this publication is still scheduled
+	 */
+	boolean isError();
+	
+	/**
+	 * Used internally by the dispatcher to indicate whether
+	 * this Publication has been delivered. Users should not
+	 * need this method.
+	 */
+	void markDelivered();
+	
+	/**
+	 * Used internally to mark the publication as being scheduled. Uses the
+	 * builder pattern for convenience.
+	 * 
+	 * @return this IMessagePublication as part of the builder pattern.
+	 */
+	IMessagePublication markScheduled();
+	
+	/**
+	 * Used internally to mark the publication as having returned an error.
+	 * Uses the builder pattern for convenience.
+	 * 
+	 * @return this IMessagePublication as part of the builder pattern.
+	 */
+	IMessagePublication setError();
+	
+	/**
+	 * Indicates whether this is a publication of a
+	 * {@Link net.engio.mbassy.common.DeadMessage}.
+	 * 
+	 * @return true if this is publication of a
+	 * {@Link net.engio.mbassy.common.DeadMessage}.
+	 */
+	boolean isDeadEvent();
+	
+	/**
+	 * Indicates whether this is a publication of a
+	 * {@Link net.engio.mbassy.common.FilteredMessage}.
+	 * 
+	 * @return true if this is publication of a
+	 * {@Link net.engio.mbassy.common.FilteredMessage}.
+	 */
+	boolean isFilteredEvent();
+}

--- a/src/main/java/net/engio/mbassy/bus/MBassador.java
+++ b/src/main/java/net/engio/mbassy/bus/MBassador.java
@@ -4,13 +4,11 @@ import net.engio.mbassy.PublicationError;
 
 import java.util.concurrent.TimeUnit;
 
-
-public class MBassador<T> extends AbstractSyncAsyncMessageBus<T, SyncAsyncPostCommand<T>> {
+public class MBassador<T> extends AbstractSyncAsyncMessageBus<T, SyncAsyncPostCommand<T>> implements IMBassador<T, SyncAsyncPostCommand<T>> {
 
     public MBassador(BusConfiguration configuration) {
         super(configuration);
     }
-
 
     public MessagePublication publishAsync(T message) {
         return addAsynchronousDeliveryRequest(createMessagePublication(message));
@@ -19,7 +17,6 @@ public class MBassador<T> extends AbstractSyncAsyncMessageBus<T, SyncAsyncPostCo
     public MessagePublication publishAsync(T message, long timeout, TimeUnit unit) {
         return addAsynchronousDeliveryRequest(createMessagePublication(message), timeout, unit);
     }
-
 
     /**
      * Synchronously publish a message to all registered listeners (this includes listeners defined for super types)
@@ -37,7 +34,6 @@ public class MBassador<T> extends AbstractSyncAsyncMessageBus<T, SyncAsyncPostCo
                     .setCause(e)
                     .setPublishedObject(message));
         }
-
     }
 
 

--- a/src/main/java/net/engio/mbassy/bus/MessagePublication.java
+++ b/src/main/java/net/engio/mbassy/bus/MessagePublication.java
@@ -17,7 +17,7 @@ import java.util.Collection;
  * @author bennidi
  *         Date: 11/16/12
  */
-public class MessagePublication {
+public class MessagePublication implements IMessagePublication {
 
     public static class Factory {
 
@@ -44,7 +44,8 @@ public class MessagePublication {
         this.state = initialState;
     }
 
-    public boolean add(Subscription subscription) {
+    @Override
+	public boolean add(Subscription subscription) {
         return subscriptions.add(subscription);
     }
 
@@ -65,23 +66,33 @@ public class MessagePublication {
         }
     }
 
-    public boolean isFinished() {
+    @Override
+	public boolean isFinished() {
         return state.equals(State.Finished);
     }
 
-    public boolean isRunning() {
+    @Override
+	public boolean isRunning() {
         return state.equals(State.Running);
     }
 
-    public boolean isScheduled() {
+    @Override
+	public boolean isScheduled() {
         return state.equals(State.Scheduled);
     }
+    
+    @Override
+    public boolean isError() {
+    	return state.equals(State.Error);
+    }
 
-    public void markDelivered() {
+    @Override
+	public void markDelivered() {
         delivered = true;
     }
 
-    public MessagePublication markScheduled() {
+    @Override
+	public MessagePublication markScheduled() {
         if (!state.equals(State.Initial)) {
             return this;
         }
@@ -89,16 +100,19 @@ public class MessagePublication {
         return this;
     }
 
-    public MessagePublication setError() {
+    @Override
+	public MessagePublication setError() {
         state = State.Error;
         return this;
     }
 
-    public boolean isDeadEvent() {
+    @Override
+	public boolean isDeadEvent() {
         return DeadMessage.class.isAssignableFrom(message.getClass());
     }
 
-    public boolean isFilteredEvent() {
+    @Override
+	public boolean isFilteredEvent() {
         return FilteredMessage.class.isAssignableFrom(message.getClass());
     }
 


### PR DESCRIPTION
I added interfaces that represent `MBassador` and `MessagePublication` to make it easier to test and mock. Also, reduced the visibility of `AbstractSyncMessageBus.handlePublicationError`, as it is really only used internally.

The new interfaces also have javadoc markup.
