### PR TITLE
Added arguments to Handler annotation and Handler Metadata.

### DIFF
--- a/src/main/java/net/engio/mbassy/listener/Handler.java
+++ b/src/main/java/net/engio/mbassy/listener/Handler.java
@@ -62,5 +62,9 @@ public @interface Handler {
      */
     Class<? extends HandlerInvocation> invocation() default ReflectiveHandlerInvocation.class;
 
-
+    /**
+     * This doesn't do anything, but it allows adding fixed arguments to be passed into anything
+     * that wants to look at the metadata. Most typically, this would be in {@link IMessageFilter#accepts}. 
+     */
+    String[] arguments() default {};
 }

--- a/src/main/java/net/engio/mbassy/listener/MessageHandlerMetadata.java
+++ b/src/main/java/net/engio/mbassy/listener/MessageHandlerMetadata.java
@@ -115,8 +115,11 @@ public class MessageHandlerMetadata {
         return acceptsSubtypes;
     }
 
-
     public boolean isEnabled() {
         return handlerConfig.enabled();
+    }
+    
+    public String[] getArguments() {
+    	return handlerConfig.arguments();
     }
 }


### PR DESCRIPTION
I thought about how to check for generic type safety for a long time, obviously it's impossible because of erasure, but this is the best I was able to come up with. Now the programmer can add arbitrary arguments to filters, which would allow this:

```
public GenericListFilter extends IMessageFilter {
    @Override
    public final boolean accepts(Object message, MessageHandlerMetadata metadata) {
        if(metadata.arguments().length == 0) return true;
        if(!message instanceof List.class) return false;
        List<?> list = (List<?>) message;
        if(list.isEmpty()) return true;
        return list.get(0).getClass().getSimpleName().equals(arguments[0]);
    }
}
```

And then do 

```
@Handler(filters=GenericListFilter.class, arguments="String")
public void handleStringList(List<String> message) {  // No risk of heap pollution now!
```

Another option would be to have a separate Filter class for each generic type, but that seems very cumbersome - though, it is what my code does currently. Thoughts?
