### PR TITLE
Created ISyncBusConfiguration

### DIFF
--- a/src/main/java/net/engio/mbassy/bus/AbstractSyncMessageBus.java
+++ b/src/main/java/net/engio/mbassy/bus/AbstractSyncMessageBus.java
@@ -2,7 +2,7 @@ package net.engio.mbassy.bus;
 
 import net.engio.mbassy.IPublicationErrorHandler;
 import net.engio.mbassy.PublicationError;
-import net.engio.mbassy.bus.config.IBusConfiguration;
+import net.engio.mbassy.bus.config.ISyncBusConfiguration;
 import net.engio.mbassy.bus.publication.IPublicationCommand;
 import net.engio.mbassy.common.DeadMessage;
 import net.engio.mbassy.subscription.Subscription;
@@ -32,7 +32,7 @@ public abstract class AbstractSyncMessageBus<T, P extends IPublicationCommand> i
     private final BusRuntime runtime;
 
 
-    public AbstractSyncMessageBus(IBusConfiguration configuration) {
+    public AbstractSyncMessageBus(ISyncBusConfiguration configuration) {
         this.runtime = new BusRuntime(this);
         this.runtime.add("error.handlers", getRegisteredErrorHandlers());
         this.subscriptionManager = new SubscriptionManager(configuration.getMetadataReader(),

--- a/src/main/java/net/engio/mbassy/bus/SyncMessageBus.java
+++ b/src/main/java/net/engio/mbassy/bus/SyncMessageBus.java
@@ -1,7 +1,7 @@
 package net.engio.mbassy.bus;
 
 import net.engio.mbassy.PublicationError;
-import net.engio.mbassy.bus.config.IBusConfiguration;
+import net.engio.mbassy.bus.config.ISyncBusConfiguration;
 import net.engio.mbassy.bus.publication.IPublicationCommand;
 
 /**
@@ -14,7 +14,7 @@ import net.engio.mbassy.bus.publication.IPublicationCommand;
 public class SyncMessageBus<T> extends AbstractSyncMessageBus<T, SyncMessageBus.SyncPostCommand>{
 
 
-    public SyncMessageBus(IBusConfiguration configuration) {
+    public SyncMessageBus(ISyncBusConfiguration configuration) {
         super(configuration);
     }
 

--- a/src/main/java/net/engio/mbassy/bus/config/IBusConfiguration.java
+++ b/src/main/java/net/engio/mbassy/bus/config/IBusConfiguration.java
@@ -1,8 +1,6 @@
 package net.engio.mbassy.bus.config;
 
 import net.engio.mbassy.bus.MessagePublication;
-import net.engio.mbassy.listener.MetadataReader;
-import net.engio.mbassy.subscription.SubscriptionFactory;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -15,19 +13,13 @@ import java.util.concurrent.ThreadFactory;
  * Time: 9:56 AM
  * To change this template use File | Settings | File Templates.
  */
-public interface IBusConfiguration {
+public interface IBusConfiguration extends ISyncBusConfiguration {
 
     int getNumberOfMessageDispatchers();
 
     ExecutorService getExecutorForAsynchronousHandlers();
 
     BlockingQueue<MessagePublication> getPendingMessagesQueue();
-
-    MessagePublication.Factory getMessagePublicationFactory();
-
-    MetadataReader getMetadataReader();
-
-    SubscriptionFactory getSubscriptionFactory();
 
     ThreadFactory getThreadFactoryForAsynchronousMessageDispatch();
 

--- a/src/main/java/net/engio/mbassy/bus/config/ISyncBusConfiguration.java
+++ b/src/main/java/net/engio/mbassy/bus/config/ISyncBusConfiguration.java
@@ -1,0 +1,15 @@
+package net.engio.mbassy.bus.config;
+
+import net.engio.mbassy.bus.MessagePublication;
+import net.engio.mbassy.listener.MetadataReader;
+import net.engio.mbassy.subscription.SubscriptionFactory;
+
+public interface ISyncBusConfiguration {
+
+	MessagePublication.Factory getMessagePublicationFactory();
+
+	MetadataReader getMetadataReader();
+
+	SubscriptionFactory getSubscriptionFactory();
+
+}

--- a/src/main/java/net/engio/mbassy/bus/config/SyncBusConfiguration.java
+++ b/src/main/java/net/engio/mbassy/bus/config/SyncBusConfiguration.java
@@ -10,7 +10,7 @@ import net.engio.mbassy.subscription.SubscriptionFactory;
  * @author bennidi
  *         Date: 3/29/13
  */
-public class SyncBusConfiguration<Config extends SyncBusConfiguration<Config>> {
+public class SyncBusConfiguration<C extends SyncBusConfiguration<C>> implements ISyncBusConfiguration {
 
     protected SubscriptionFactory subscriptionFactory;
     protected MetadataReader metadataReader;
@@ -34,17 +34,17 @@ public class SyncBusConfiguration<Config extends SyncBusConfiguration<Config>> {
         return metadataReader;
     }
 
-    public Config setMetadataReader(MetadataReader metadataReader) {
+    public C setMetadataReader(MetadataReader metadataReader) {
         this.metadataReader = metadataReader;
-        return (Config)this;
+        return (C) this;
     }
 
     public SubscriptionFactory getSubscriptionFactory() {
         return subscriptionFactory;
     }
 
-    public Config setSubscriptionFactory(SubscriptionFactory subscriptionFactory) {
+    public C setSubscriptionFactory(SubscriptionFactory subscriptionFactory) {
         this.subscriptionFactory = subscriptionFactory;
-        return (Config)this;
+        return (C) this;
     }
 }

--- a/src/test/java/net/engio/mbassy/SyncBusTest.java
+++ b/src/test/java/net/engio/mbassy/SyncBusTest.java
@@ -4,6 +4,7 @@ import net.engio.mbassy.bus.ISyncMessageBus;
 import net.engio.mbassy.bus.MBassador;
 import net.engio.mbassy.bus.SyncMessageBus;
 import net.engio.mbassy.bus.config.BusConfiguration;
+import net.engio.mbassy.bus.config.SyncBusConfiguration;
 import net.engio.mbassy.common.ConcurrentExecutor;
 import net.engio.mbassy.common.ListenerFactory;
 import net.engio.mbassy.common.MessageBusTest;
@@ -16,6 +17,7 @@ import net.engio.mbassy.listeners.MessagesListener;
 import net.engio.mbassy.messages.MessageTypes;
 import net.engio.mbassy.messages.MultipartMessage;
 import net.engio.mbassy.messages.StandardMessage;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -186,7 +188,7 @@ public abstract class SyncBusTest extends MessageBusTest {
 
         @Override
         protected ISyncMessageBus getSyncMessageBus() {
-            return new SyncMessageBus(BusConfiguration.Default());
+            return new SyncMessageBus(new SyncBusConfiguration());
         }
     }
 


### PR DESCRIPTION
Previously, SyncMessageBus required a full IBusConfiguration, which
has lots of methods about threading, etc. However, if you want a
purely Sync bus that never uses multithreading, you probably don't
want to create all those threads and dispatchers. This change allows
you to call `new SyncMessageBus(new SyncBusConfiguration())`, and
get an entirely multithreading-free Bus.
