### PR TITLE
fix issue where millions of ISetEntries would pile up and never be removed

### DIFF
--- a/src/main/java/net/engio/mbassy/common/AbstractConcurrentSet.java
+++ b/src/main/java/net/engio/mbassy/common/AbstractConcurrentSet.java
@@ -96,18 +96,28 @@ public abstract class AbstractConcurrentSet<T> implements IConcurrentSet<T> {
                 if (listelement == null) {
                     return false; //removed by other thread
                 }
-                if (listelement != head) {
-                    listelement.remove();
-                } else {
-                    ISetEntry<T> oldHead = head;
-                    head = head.next();
-                    //oldHead.clear(); // optimize for GC not possible because of potentially running iterators
-                }
+                remove(listelement);
                 entries.remove(element);
             } finally {
                 writeLock.unlock();
             }
             return true;
+        }
+    }
+
+    protected void remove(final ISetEntry<T> listelement) {
+        Lock writeLock = lock.writeLock();
+        try {
+            writeLock.lock();
+            if (listelement != head) {
+                listelement.remove();
+            } else {
+                ISetEntry<T> oldHead = head;
+                head = head.next();
+                //oldHead.clear(); // optimize for GC not possible because of potentially running iterators
+            }
+        } finally {
+            writeLock.unlock();
         }
     }
 

--- a/src/main/java/net/engio/mbassy/common/WeakConcurrentSet.java
+++ b/src/main/java/net/engio/mbassy/common/WeakConcurrentSet.java
@@ -60,10 +60,19 @@ public class WeakConcurrentSet<T> extends AbstractConcurrentSet<T>{
                     return;
                 }
                 ISetEntry<T> newCurrent = current.next();
-                WeakConcurrentSet.this.remove(current.getValue());
+                WeakConcurrentSet.this.remove(current.getValue(), current);
                 current = newCurrent;
             }
         };
+    }
+
+    private void remove(final T value, final ISetEntry<T> current) {
+        // if WeakHashMap entries or the WeakReference value have been
+        // garbage collected, the ISetEntry list entry will never be
+        // removed so remove it explicitly
+        if (!remove(value)) {
+            remove(current);
+        }
     }
 
     @Override


### PR DESCRIPTION
After running on our production server for a few days we experienced slowdowns and a heap dump revealed millions of ISetEntries so I investigated and found out that garbage collected values of ISetEntries cannot be removed anymore with the existing method so I changed it a bit to allow removal of ISetEntries themselves.
