### PR TITLE
filterref - allows for java 8 style lambdas for filters

### DIFF
--- a/src/main/java/net/engio/mbassy/common/ReflectionUtils.java
+++ b/src/main/java/net/engio/mbassy/common/ReflectionUtils.java
@@ -135,4 +135,17 @@ public class ReflectionUtils
 		return true;
 	}
 
+    public static <T> T getField(String filterRef, Class<T> intendedSubclass) {
+        int lastDot = filterRef.lastIndexOf('.');
+        if (lastDot == -1) throw new IllegalArgumentException("Field reference should be composed of <classname>.<fieldname>");
+        String className = filterRef.substring(0, lastDot);
+        String fieldName = filterRef.substring(lastDot+1);
+        try {
+            Class<?> clazz = Class.forName(className);
+            return intendedSubclass.cast(clazz.getField(fieldName).get(null));
+        } catch (ClassNotFoundException | IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
+            throw new IllegalArgumentException("Unable to access field", e);
+        }
+    }
+
 }

--- a/src/main/java/net/engio/mbassy/listener/Handler.java
+++ b/src/main/java/net/engio/mbassy/listener/Handler.java
@@ -23,7 +23,11 @@ public @interface Handler {
      */
     Filter[] filters() default {};
     
-    
+    /**
+     * Adds a filter by name. It is a public static final field reference in class.field form.
+     * Allows access to using lambdas for filters in java 8 (until annotations support field or method refs in java 9)
+     */
+    String[] filterRefs() default {};
     /**
      * Defines a filter condition as Expression Language. This can be used to filter the events based on 
      * attributes of the event object. Note that the expression must resolve to either

--- a/src/main/java/net/engio/mbassy/listener/MetadataReader.java
+++ b/src/main/java/net/engio/mbassy/listener/MetadataReader.java
@@ -31,10 +31,10 @@ public class MetadataReader {
 
     // retrieve all instances of filters associated with the given subscription
     private IMessageFilter[] getFilter(Handler subscription) {
-        if (subscription.filters().length == 0) {
+        if (subscription.filters().length == 0 && subscription.filterRefs().length == 0) {
             return null;
         }
-        IMessageFilter[] filters = new IMessageFilter[subscription.filters().length];
+        IMessageFilter[] filters = new IMessageFilter[subscription.filters().length + subscription.filterRefs().length];
         int i = 0;
         for (Filter filterDef : subscription.filters()) {
             IMessageFilter filter = filterCache.get(filterDef.value());
@@ -46,6 +46,11 @@ public class MetadataReader {
                     throw new RuntimeException(e);// propagate as runtime exception
                 }
             }
+            filters[i] = filter;
+            i++;
+        }
+        for (String filterRef : subscription.filterRefs()) {
+            IMessageFilter<?> filter = ReflectionUtils.getField(filterRef,IMessageFilter.class);
             filters[i] = filter;
             i++;
         }


### PR DESCRIPTION
Unfortunately, annotations in java 8 don't support field refs or other things (yet).

This PR implements "filterRef" - an array of strings in ```<className>.<fieldName>``` format for referencing public static final fields commonly created by lambdas.

This allows for this kind of java 8 specific construct:
Definition:
```java
public class MyClass {
    public static final IMessageFilter<LifecycleEvent> ServerStarted = (event, metadata) -> event.phase == Phase.STARTED;
}
```

Use:
```java
    @Handler(filterRefs="my.package.MyClass.ServerStarted")
    public void init(LifecycleEvent e) { System.out.println("HELLO 1 " + e.phase); };
```

I hope you accept. I think it'll make your stuff a clear winner for annotation based events, especially with Java 8 :)