### PR TITLE
ErrorHandler to Configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ repositories {
 dependencies {
 
     testCompile "junit:junit:4.10"
+    testCompile 'org.assertj:assertj-core:2.0.0'
+    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'com.mycila.testing.plugins:mycila-testing-mockito:2.8'
+
     testCompile 'org.slf4j:slf4j-api:1.7.5'
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,27 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mycila.testing.plugins</groupId>
+            <artifactId>mycila-testing-mockito</artifactId>
+            <version>2.8</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.5</version>

--- a/src/main/java/net/engio/mbassy/bus/BusRuntime.java
+++ b/src/main/java/net/engio/mbassy/bus/BusRuntime.java
@@ -49,4 +49,5 @@ public class BusRuntime {
         return properties.containsKey(key);
     }
 
+
 }

--- a/src/main/java/net/engio/mbassy/bus/MBassador.java
+++ b/src/main/java/net/engio/mbassy/bus/MBassador.java
@@ -4,6 +4,7 @@ import net.engio.mbassy.bus.common.IMessageBus;
 import net.engio.mbassy.bus.config.BusConfiguration;
 import net.engio.mbassy.bus.config.Feature;
 import net.engio.mbassy.bus.config.IBusConfiguration;
+import net.engio.mbassy.bus.error.IPublicationErrorHandler;
 import net.engio.mbassy.bus.error.PublicationError;
 import net.engio.mbassy.bus.publication.SyncAsyncPostCommand;
 
@@ -13,16 +14,39 @@ import java.util.concurrent.TimeUnit;
 public class MBassador<T> extends AbstractSyncAsyncMessageBus<T, SyncAsyncPostCommand<T>> implements IMessageBus<T, SyncAsyncPostCommand<T>> {
 
 
-    public MBassador(IBusConfiguration configuration) {
-        super(configuration);
-    }
-
+    /**
+     * Default constructor using default setup. super() will also add a default publication error logger
+     */
     public MBassador(){
         this(new BusConfiguration()
                 .addFeature(Feature.SyncPubSub.Default())
                 .addFeature(Feature.AsynchronousHandlerInvocation.Default())
                 .addFeature(Feature.AsynchronousMessageDispatch.Default()));
     }
+
+    /**
+     * Construct with default settings and specified publication error handler
+     *
+     * @param errorHandler
+     */
+    public MBassador(IPublicationErrorHandler errorHandler) {
+        super(new BusConfiguration().addFeature(Feature.SyncPubSub.Default())
+                                    .addFeature(Feature.AsynchronousHandlerInvocation.Default())
+                                    .addFeature(Feature.AsynchronousMessageDispatch.Default())
+                                    .addPublicationErrorHandler(errorHandler));
+    }
+
+    /**
+     * Construct with fully specified configuration
+     *
+     * @param configuration
+     */
+    public MBassador(IBusConfiguration configuration) {
+        super(configuration);
+    }
+
+
+
 
 
     public IMessagePublication publishAsync(T message) {

--- a/src/main/java/net/engio/mbassy/bus/SyncMessageBus.java
+++ b/src/main/java/net/engio/mbassy/bus/SyncMessageBus.java
@@ -3,18 +3,40 @@ package net.engio.mbassy.bus;
 import net.engio.mbassy.bus.common.ErrorHandlingSupport;
 import net.engio.mbassy.bus.common.GenericMessagePublicationSupport;
 import net.engio.mbassy.bus.common.PubSubSupport;
+import net.engio.mbassy.bus.config.BusConfiguration;
+import net.engio.mbassy.bus.config.Feature;
 import net.engio.mbassy.bus.config.IBusConfiguration;
+import net.engio.mbassy.bus.error.IPublicationErrorHandler;
 import net.engio.mbassy.bus.error.PublicationError;
 import net.engio.mbassy.bus.publication.IPublicationCommand;
 
 /**
  * A message bus implementation that offers only synchronous message publication. Using this bus
  * will not create any new threads.
- *
  */
-public class SyncMessageBus<T> extends AbstractPubSubSupport<T> implements PubSubSupport<T>, ErrorHandlingSupport, GenericMessagePublicationSupport<T, SyncMessageBus.SyncPostCommand>{
+public class SyncMessageBus<T> extends AbstractPubSubSupport<T> implements PubSubSupport<T>, ErrorHandlingSupport, GenericMessagePublicationSupport<T,
+        SyncMessageBus.SyncPostCommand> {
 
+    /**
+     * Default constructor using default setup. super() will also add a default publication error logger
+     */
+    public SyncMessageBus() {
+        super(new BusConfiguration().addFeature(Feature.SyncPubSub.Default()));
+    }
 
+    /**
+     * Construct with default settings and specified publication error handler
+     * @param errorHandler
+     */
+    public SyncMessageBus(IPublicationErrorHandler errorHandler) {
+        super(new BusConfiguration().addFeature(Feature.SyncPubSub.Default()).addPublicationErrorHandler(errorHandler));
+    }
+
+    /**
+     * Construct with fully specified configuration
+     *
+     * @param configuration
+     */
     public SyncMessageBus(IBusConfiguration configuration) {
         super(configuration);
     }
@@ -25,10 +47,9 @@ public class SyncMessageBus<T> extends AbstractPubSubSupport<T> implements PubSu
             IMessagePublication publication = createMessagePublication(message);
             publication.execute();
         } catch (Throwable e) {
-            handlePublicationError(new PublicationError()
-                    .setMessage("Error during publication of message")
-                    .setCause(e)
-                    .setPublishedMessage(message));
+            handlePublicationError(new PublicationError().setMessage("Error during publication of message")
+                                                         .setCause(e)
+                                                         .setPublishedMessage(message));
         }
     }
 

--- a/src/main/java/net/engio/mbassy/bus/common/ErrorHandlingSupport.java
+++ b/src/main/java/net/engio/mbassy/bus/common/ErrorHandlingSupport.java
@@ -1,21 +1,20 @@
 package net.engio.mbassy.bus.common;
 
+import net.engio.mbassy.bus.config.IBusConfiguration;
 import net.engio.mbassy.bus.error.IPublicationErrorHandler;
 
 import java.util.Collection;
 
+/**
+ * Publication errors may occur at various points of time during message delivery. A handler may throw an exception,
+ * may not be accessible due to security constraints or is not annotated properly.
+ * In any of all possible cases a publication error is created and passed to each of the registered error handlers.
+ * Error handlers can be added via the {@link IBusConfiguration}.
+ *
+ */
 
 public interface ErrorHandlingSupport {
 
-    /**
-     * Publication errors may occur at various points of time during message delivery. A handler may throw an exception,
-     * may not be accessible due to security constraints or is not annotated properly.
-     * In any of all possible cases a publication error is created and passed to each of the registered error handlers.
-     * A call to this method will add the given error handler to the chain
-     *
-     * @param errorHandler
-     */
-    void addErrorHandler(IPublicationErrorHandler errorHandler);
 
     /**
      * Returns an immutable collection containing all the registered error handlers

--- a/src/main/java/net/engio/mbassy/bus/config/BusConfiguration.java
+++ b/src/main/java/net/engio/mbassy/bus/config/BusConfiguration.java
@@ -1,9 +1,8 @@
 package net.engio.mbassy.bus.config;
 
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import net.engio.mbassy.bus.error.IPublicationErrorHandler;
+
+import java.util.*;
 
 /**
  * The bus configuration holds various parameters that can be used to customize the bus' runtime behaviour.
@@ -12,7 +11,9 @@ public class BusConfiguration implements IBusConfiguration {
 
     // the registered properties
     private final Map<Object, Object> properties = new HashMap<Object, Object>();
-    private final List<ConfigurationErrorHandler> errorHandlerList = new LinkedList<ConfigurationErrorHandler>();
+    private final List<ConfigurationErrorHandler> configurationErrorHandlers = new LinkedList<ConfigurationErrorHandler>();
+    // these are transferred to the bus to receive all errors that occur during message dispatch or message handling
+    private final List<IPublicationErrorHandler> publicationErrorHandlers = new ArrayList<IPublicationErrorHandler>();
 
     public BusConfiguration() {
         super();
@@ -47,14 +48,25 @@ public class BusConfiguration implements IBusConfiguration {
 
     @Override
     public IBusConfiguration addConfigurationErrorHandler(ConfigurationErrorHandler handler) {
-        errorHandlerList.add(handler);
+        configurationErrorHandlers.add(handler);
         return this;
     }
 
     @Override
     public void handleError(ConfigurationError error) {
-        for(ConfigurationErrorHandler errorHandler : errorHandlerList){
+        for(ConfigurationErrorHandler errorHandler : configurationErrorHandlers){
             errorHandler.handle(error);
         }
+    }
+
+@Override
+    public final BusConfiguration addPublicationErrorHandler(IPublicationErrorHandler handler) {
+            publicationErrorHandlers.add(handler);
+    return this;
+    }
+
+    @Override
+    public Collection<IPublicationErrorHandler> getRegisteredPublicationErrorHandlers() {
+        return Collections.unmodifiableCollection(publicationErrorHandlers);
     }
 }

--- a/src/main/java/net/engio/mbassy/bus/config/IBusConfiguration.java
+++ b/src/main/java/net/engio/mbassy/bus/config/IBusConfiguration.java
@@ -1,5 +1,9 @@
 package net.engio.mbassy.bus.config;
 
+import net.engio.mbassy.bus.error.IPublicationErrorHandler;
+
+import java.util.Collection;
+
 /**
  * The configuration of message bus instances is feature driven, e.g. configuration parameters
  * are grouped into {@link Feature}.
@@ -64,5 +68,10 @@ public interface IBusConfiguration{
      * Calls all ConfigurationErrorHandlers
      */
     void handleError(ConfigurationError error);
+
+    BusConfiguration addPublicationErrorHandler(IPublicationErrorHandler handler);
+
+    Collection<IPublicationErrorHandler> getRegisteredPublicationErrorHandlers();
+
 
 }

--- a/src/test/java/net/engio/mbassy/SyncAsyncTest.java
+++ b/src/test/java/net/engio/mbassy/SyncAsyncTest.java
@@ -1,7 +1,7 @@
 package net.engio.mbassy;
 
 import net.engio.mbassy.bus.MBassador;
-import net.engio.mbassy.bus.common.Properties;
+import net.engio.mbassy.bus.config.IBusConfiguration;
 import net.engio.mbassy.bus.error.IPublicationErrorHandler;
 import net.engio.mbassy.bus.error.PublicationError;
 import net.engio.mbassy.common.*;
@@ -132,8 +132,11 @@ public class SyncAsyncTest extends MessageBusTest {
             }
         };
 
-        final MBassador bus = new MBassador(SyncAsync()
-                .setProperty(Properties.Handler.PublicationError, ExceptionCounter));
+        //DS: Exception counter added via config
+        IBusConfiguration config = SyncAsync();
+        config.addPublicationErrorHandler(ExceptionCounter);
+        final MBassador bus = new MBassador(config);
+
         ListenerFactory listeners = new ListenerFactory()
                 .create(InstancesPerListener, ExceptionThrowingListener.class);
         ConcurrentExecutor.runConcurrent(TestUtil.subscriber(bus, listeners), ConcurrentUnits);

--- a/src/test/java/net/engio/mbassy/bus/AbstractPubSubSupportTest.java
+++ b/src/test/java/net/engio/mbassy/bus/AbstractPubSubSupportTest.java
@@ -1,0 +1,189 @@
+package net.engio.mbassy.bus;
+
+import com.mycila.testing.junit.MycilaJunitRunner;
+import net.engio.mbassy.bus.config.IBusConfiguration;
+import net.engio.mbassy.bus.error.IPublicationErrorHandler;
+import net.engio.mbassy.bus.error.PublicationError;
+import net.engio.mbassy.common.MessageBusTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Added for changes proposed under https://github.com/bennidi/mbassador/issues/106
+ * <p/>
+ * Created by David Sowerby on 13/04/15.
+ */
+@RunWith(MycilaJunitRunner.class)
+public class AbstractPubSubSupportTest {
+
+    IBusConfiguration configuration;
+
+    @Mock
+    IPublicationErrorHandler handler1;
+
+    @Mock
+    IPublicationErrorHandler handler2;
+
+    @Mock
+    IPublicationErrorHandler handler3;
+
+    @Mock
+    PublicationError publicationError;
+
+
+    @Before
+    public void setup() {
+        configuration = MessageBusTest.SyncAsync();
+    }
+
+
+    @Test
+    public void testHandlePublicationError_handlers_present_sync() {
+        //given
+
+        configuration.addPublicationErrorHandler(handler1);
+        configuration.addPublicationErrorHandler(handler2);
+        configuration.addPublicationErrorHandler(handler3);
+        //when
+        SyncMessageBus<String> bus = new SyncMessageBus<String>(configuration);
+        bus.handlePublicationError(publicationError);
+        //then
+        verify(handler1).handleError(publicationError);
+        verify(handler2).handleError(publicationError);
+        verify(handler3).handleError(publicationError);
+    }
+
+    @Test
+    public void testHandlePublicationError_handlers_present_async() {
+        //given
+
+        configuration.addPublicationErrorHandler(handler1);
+        configuration.addPublicationErrorHandler(handler2);
+        configuration.addPublicationErrorHandler(handler3);
+        //when
+        MBassador<String> bus = new MBassador<String>(configuration);
+        bus.handlePublicationError(publicationError);
+        //then
+        verify(handler1).handleError(publicationError);
+        verify(handler2).handleError(publicationError);
+        verify(handler3).handleError(publicationError);
+    }
+
+
+    @Test
+    public void testHandlePublicationError_construct_with_handler_sync() {
+        //given
+
+        //when
+        SyncMessageBus<String> bus = new SyncMessageBus<String>(handler1);
+        bus.handlePublicationError(publicationError);
+        //then
+        verify(handler1).handleError(publicationError);
+    }
+
+    @Test
+    public void testHandlePublicationError_constrcut_with_handler_async() {
+        //given
+
+        configuration.addPublicationErrorHandler(handler1);
+        //when
+        MBassador<String> bus = new MBassador<String>(handler1);
+        bus.handlePublicationError(publicationError);
+        //then
+        verify(handler1).handleError(publicationError);
+    }
+
+    @Test
+    public void testHandlePublicationError_no_handlers_present_construct_with_config_async() {
+        //given
+        final String errorMsg = "Test error";
+        when(publicationError.toString()).thenReturn(errorMsg);
+        PrintStream old = null;
+
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(baos);
+            old = System.out;
+            System.setOut(ps);
+            //when
+            MBassador<String> bus = new MBassador<String>(configuration);
+            assertThat(baos.toString()).contains(AbstractPubSubSupport.ERROR_HANDLER_MSG);
+            bus.handlePublicationError(publicationError);
+            //then
+            assertThat(baos.toString()).contains(errorMsg);
+
+        } finally {
+            System.out.flush();
+            if (old != null) {
+                System.setOut(old);
+            }
+        }
+
+    }
+
+    @Test
+    public void testHandlePublicationError_default_construct_sync() {
+        //given
+        final String errorMsg = "Test error";
+        when(publicationError.toString()).thenReturn(errorMsg);
+        PrintStream old = null;
+
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(baos);
+            old = System.out;
+            System.setOut(ps);
+            //when
+            SyncMessageBus<String> bus = new SyncMessageBus<String>();
+            assertThat(baos.toString()).contains(AbstractPubSubSupport.ERROR_HANDLER_MSG);
+            bus.handlePublicationError(publicationError);
+            //then
+            assertThat(baos.toString()).contains(errorMsg);
+
+        } finally {
+            System.out.flush();
+            if (old != null) {
+                System.setOut(old);
+            }
+        }
+    }
+
+    @Test
+    public void testHandlePublicationError_default_construct_async() {
+        //given
+        final String errorMsg = "Test error";
+        when(publicationError.toString()).thenReturn(errorMsg);
+        PrintStream old = null;
+
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(baos);
+            old = System.out;
+            System.setOut(ps);
+            //when
+            MBassador<String> bus = new MBassador<String>();
+            assertThat(baos.toString()).contains(AbstractPubSubSupport.ERROR_HANDLER_MSG);
+            bus.handlePublicationError(publicationError);
+            //then
+            assertThat(baos.toString()).contains(errorMsg);
+
+        } finally {
+            System.out.flush();
+            if (old != null) {
+                System.setOut(old);
+            }
+        }
+
+    }
+
+
+}

--- a/src/test/java/net/engio/mbassy/common/MessageBusTest.java
+++ b/src/test/java/net/engio/mbassy/common/MessageBusTest.java
@@ -59,8 +59,9 @@ public abstract class MessageBusTest extends AssertSupport {
         return new BusConfiguration()
             .addFeature(Feature.SyncPubSub.Default())
             .addFeature(Feature.AsynchronousHandlerInvocation.Default())
-            .addFeature(Feature.AsynchronousMessageDispatch.Default())
-            .setProperty(net.engio.mbassy.bus.common.Properties.Handler.PublicationError, new AssertionErrorHandler(failOnError));
+            .addFeature(Feature.AsynchronousMessageDispatch.Default());
+        //DS: removed as publication error handlers now in configuration object
+//            .setProperty(net.engio.mbassy.bus.common.Properties.Handler.PublicationError, new AssertionErrorHandler(failOnError));
     }
 
     public MBassador createBus(IBusConfiguration configuration) {


### PR DESCRIPTION
Should close #106

PublicationErrorHandler moved to the BusConfiguration.  There are now 3 ......constructors for each bus type (MBassador and SyncMessageBus), enabling construction with either a) all default settings, b) all defaults plus a specified error handler or c) with a fully specified configuration.

Unit tests added, build.gradle and pom.xml updated with assertj and mockito

Tested with Gradle, but not Maven I'm afraid, I'm not set up for Maven