### PR TITLE
Uniquely name each Message Bus dispatcher thread

### DIFF
--- a/src/main/java/net/engio/mbassy/bus/AbstractSyncAsyncMessageBus.java
+++ b/src/main/java/net/engio/mbassy/bus/AbstractSyncAsyncMessageBus.java
@@ -75,7 +75,7 @@ public abstract class AbstractSyncAsyncMessageBus<T, P extends ISyncAsyncPublica
                     }
                 }
             });
-            dispatcher.setName("Message dispatcher");
+            dispatcher.setName("MsgDispatcher-"+i);
             dispatchers.add(dispatcher);
             dispatcher.start();
         }


### PR DESCRIPTION
Different message dispatcher thread names makes it easier to discriminate different execution threads in log files