### PR TITLE
swallow error handler exceptions

### DIFF
--- a/src/main/java/net/engio/mbassy/bus/AbstractPubSubSupport.java
+++ b/src/main/java/net/engio/mbassy/bus/AbstractPubSubSupport.java
@@ -101,7 +101,14 @@ public abstract class AbstractPubSubSupport<T> implements PubSubSupport<T> {
 
     protected void handlePublicationError(PublicationError error) {
         for (IPublicationErrorHandler errorHandler : errorHandlers) {
-            errorHandler.handleError(error);
+            try
+            {
+                errorHandler.handleError(error);
+            }
+            catch (Throwable ex)
+            {
+                ex.printStackTrace();
+            }
         }
     }
 

--- a/src/test/java/net/engio/mbassy/bus/AbstractPubSubSupportTest.java
+++ b/src/test/java/net/engio/mbassy/bus/AbstractPubSubSupportTest.java
@@ -1,6 +1,7 @@
 package net.engio.mbassy.bus;
 
 import com.mycila.testing.junit.MycilaJunitRunner;
+import junit.framework.Assert;
 import net.engio.mbassy.bus.config.IBusConfiguration;
 import net.engio.mbassy.bus.error.IPublicationErrorHandler;
 import net.engio.mbassy.bus.error.PublicationError;
@@ -12,6 +13,7 @@ import org.mockito.Mock;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -183,5 +185,17 @@ public class AbstractPubSubSupportTest {
 
     }
 
-
+    @Test
+    public void testHandlePublicationError_raises_exception() {
+        final AtomicInteger invocationCounter = new AtomicInteger(0);
+        SyncMessageBus<String> bus = new SyncMessageBus<String>(new IPublicationErrorHandler() {
+            @Override
+            public void handleError(PublicationError error) {
+                invocationCounter.incrementAndGet();
+                throw new RuntimeException("exception encountered in error handler");
+            }
+        });
+        bus.handlePublicationError(publicationError);
+        Assert.assertEquals(1, invocationCounter.get());
+    }
 }


### PR DESCRIPTION
Exceptions raised by error handlers can terminate the async msg dispatcher.
This PR replaces PR #127 