### PR TITLE
Add event bus pause/resume support. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ mvn-local-repo/**/*
 release.properties
 /.classpath
 /.project
+/build/

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 target/**/*
 target/**
 classes/
-
+bin/
 
 # the local maven repository #
 lib/
@@ -26,3 +26,7 @@ release.properties
 /.classpath
 /.project
 /build/
+
+# gradle configuration files #
+.gradle/
+

--- a/src/main/java/net/engio/mbassy/bus/AbstractPauseSyncAsyncMessageBus.java
+++ b/src/main/java/net/engio/mbassy/bus/AbstractPauseSyncAsyncMessageBus.java
@@ -4,6 +4,11 @@ import net.engio.mbassy.bus.common.AsyncPubSubPauseSupport;
 import net.engio.mbassy.bus.config.IBusConfiguration;
 import net.engio.mbassy.bus.publication.ISyncAsyncPublicationCommand;
 
+/**
+ *
+ * @author Brian Groenke [groenke.5@osu.edu]
+ *
+ */
 public abstract class AbstractPauseSyncAsyncMessageBus<T, P extends ISyncAsyncPublicationCommand>
                                                       extends AbstractSyncAsyncMessageBus<T, P>
                                                       implements AsyncPubSubPauseSupport<T> {
@@ -23,7 +28,7 @@ public abstract class AbstractPauseSyncAsyncMessageBus<T, P extends ISyncAsyncPu
 
     @Override
     public boolean resume(final PublishMode publishMode, final FlushMode flushMode) {
-        if (!isPaused() || countInQueue() == 0) return countInQueue() == 0;
+        if (!isPaused() && countInQueue() == 0) return true;
 
         switch (publishMode) {
         case SYNC:
@@ -40,8 +45,8 @@ public abstract class AbstractPauseSyncAsyncMessageBus<T, P extends ISyncAsyncPu
      * Equivalent to <code>resume(PublishMode.SYNC, FlushMode.ATOMIC)</code>
      */
     @Override
-    public void resume() {
-        resume(PublishMode.SYNC, FlushMode.ATOMIC);
+    public boolean resume() {
+        return resume(PublishMode.SYNC, FlushMode.ATOMIC);
     }
 
     /**

--- a/src/main/java/net/engio/mbassy/bus/AbstractPauseSyncAsyncMessageBus.java
+++ b/src/main/java/net/engio/mbassy/bus/AbstractPauseSyncAsyncMessageBus.java
@@ -14,6 +14,7 @@ public abstract class AbstractPauseSyncAsyncMessageBus<T, P extends ISyncAsyncPu
                                                       implements AsyncPubSubPauseSupport<T> {
 
     private final Publisher<T> asyncResumePublisher = new Publisher<T>() {
+
         @Override
         public void onResume(final T msg) {
             publishAsync(msg);
@@ -36,8 +37,8 @@ public abstract class AbstractPauseSyncAsyncMessageBus<T, P extends ISyncAsyncPu
         case ASYNC:
             return resumeAndPublish(flushMode, asyncResumePublisher);
         default:
-            throw new IllegalArgumentException("Unrecognized value for " + PublishMode.class.getSimpleName() + ": "
-                            + publishMode);
+            throw new IllegalArgumentException(
+                "Unrecognized value for " + PublishMode.class.getSimpleName() + ": " + publishMode);
         }
     }
 

--- a/src/main/java/net/engio/mbassy/bus/AbstractPauseSyncAsyncMessageBus.java
+++ b/src/main/java/net/engio/mbassy/bus/AbstractPauseSyncAsyncMessageBus.java
@@ -1,0 +1,53 @@
+package net.engio.mbassy.bus;
+
+import net.engio.mbassy.bus.common.AsyncPubSubPauseSupport;
+import net.engio.mbassy.bus.config.IBusConfiguration;
+import net.engio.mbassy.bus.publication.ISyncAsyncPublicationCommand;
+
+public abstract class AbstractPauseSyncAsyncMessageBus<T, P extends ISyncAsyncPublicationCommand>
+                                                      extends AbstractSyncAsyncMessageBus<T, P>
+                                                      implements AsyncPubSubPauseSupport<T> {
+
+    private final Publisher<T> asyncResumePublisher = new Publisher<T>() {
+        @Override
+        public void onResume(final T msg) {
+            publishAsync(msg);
+        }
+    };
+
+    protected AbstractPauseSyncAsyncMessageBus(final IBusConfiguration configuration) {
+        super(configuration);
+    }
+
+    protected abstract IMessagePublication publishAsync(T msg);
+
+    @Override
+    public boolean resume(final PublishMode publishMode, final FlushMode flushMode) {
+        if (!isPaused() || countInQueue() == 0) return countInQueue() == 0;
+
+        switch (publishMode) {
+        case SYNC:
+            return resumeAndPublish(flushMode, syncResumePublisher);
+        case ASYNC:
+            return resumeAndPublish(flushMode, asyncResumePublisher);
+        default:
+            throw new IllegalArgumentException("Unrecognized value for " + PublishMode.class.getSimpleName() + ": "
+                            + publishMode);
+        }
+    }
+
+    /**
+     * Equivalent to <code>resume(PublishMode.SYNC, FlushMode.ATOMIC)</code>
+     */
+    @Override
+    public void resume() {
+        resume(PublishMode.SYNC, FlushMode.ATOMIC);
+    }
+
+    /**
+     * Equivalent to <code>resume(PublishMode.ASYNC, FlushMode.ATOMIC)</code>
+     */
+    public void resumeAsync() {
+        resume(PublishMode.ASYNC, FlushMode.ATOMIC);
+    }
+}

--- a/src/main/java/net/engio/mbassy/bus/AbstractPubSubPauseSupport.java
+++ b/src/main/java/net/engio/mbassy/bus/AbstractPubSubPauseSupport.java
@@ -8,13 +8,15 @@ import net.engio.mbassy.bus.common.PubSubPauseSupport;
 import net.engio.mbassy.bus.config.IBusConfiguration;
 
 /**
- * Top level implementation for message bus pause/resume support. It is the responsibility of all implementation
- * classes to check the current pause state via {@link #isPaused()} and enqueue messages during a pause via
+ * Top level implementation for message bus pause/resume support. It is the
+ * responsibility of all implementation classes to check the current pause state
+ * via {@link #isPaused()} and enqueue messages during a pause via
  * {@link #enqueueMessageOnPause(Object)}.
  *
  * @author Brian Groenke [groenke.5@osu.edu]
  *
- * @param <T> the message type
+ * @param <T>
+ *            the message type
  */
 public abstract class AbstractPubSubPauseSupport<T> extends AbstractPubSubSupport<T> implements PubSubPauseSupport<T> {
 
@@ -84,8 +86,8 @@ public abstract class AbstractPubSubPauseSupport<T> extends AbstractPubSubSuppor
             flushPauseQueue(publisher);
             break;
         default:
-            throw new IllegalArgumentException("Unrecognized value for " + FlushMode.class.getSimpleName() + ": "
-                            + flushMode);
+            throw new IllegalArgumentException(
+                "Unrecognized value for " + FlushMode.class.getSimpleName() + ": " + flushMode);
         }
 
         return msgPauseQueue.isEmpty();

--- a/src/main/java/net/engio/mbassy/bus/AbstractPubSubPauseSupport.java
+++ b/src/main/java/net/engio/mbassy/bus/AbstractPubSubPauseSupport.java
@@ -1,0 +1,102 @@
+package net.engio.mbassy.bus;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import net.engio.mbassy.bus.common.PubSubPauseSupport;
+import net.engio.mbassy.bus.config.IBusConfiguration;
+
+public abstract class AbstractPubSubPauseSupport<T> extends AbstractPubSubSupport<T> implements PubSubPauseSupport<T> {
+
+    private final ConcurrentLinkedQueue<T> msgPauseQueue = new ConcurrentLinkedQueue<T>();
+    private final AtomicBoolean paused = new AtomicBoolean();
+    private final Lock pauseLock = new ReentrantLock();
+
+    protected final Publisher<T> syncResumePublisher = new Publisher<T>() {
+
+        @Override
+        public void onResume(final T msg) {
+            publish(msg);
+        }
+    };
+
+    public AbstractPubSubPauseSupport(final IBusConfiguration configuration) {
+        super(configuration);
+    }
+
+    @Override
+    public void pause() {
+        // return immeidately if already paused
+        if (paused.get()) return;
+        // acquire write lock; blocks until
+        pauseLock.lock();
+        paused.set(true);
+        pauseLock.unlock();
+    }
+
+    @Override
+    public void resume() {
+        resume(FlushMode.ATOMIC);
+    }
+
+    @Override
+    public boolean resume(final FlushMode flushMode) {
+        if (!paused.get() || msgPauseQueue.isEmpty()) return msgPauseQueue.isEmpty();
+
+        return resumeAndPublish(flushMode, syncResumePublisher);
+    }
+
+    @Override
+    public boolean isPaused() {
+        return paused.get();
+    }
+
+    @Override
+    public int countInQueue() {
+        return msgPauseQueue.size();
+    }
+
+    /**
+     * Resumes and publishes all events in the queue according the given
+     * <code>flushMode</code> and using the given publisher.
+     *
+     * @return true if the queue was flushed completely, false otherwise
+     */
+    protected final boolean resumeAndPublish(final FlushMode flushMode, final Publisher<T> publisher) {
+        switch (flushMode) {
+        case ATOMIC:
+            pauseLock.lock(); // prevent pausing during flush
+            paused.set(false);
+            flushPauseQueue(publisher);
+            pauseLock.unlock();
+            break;
+        case NONATOMIC:
+            paused.set(false);
+            flushPauseQueue(publisher);
+            break;
+        default:
+            throw new IllegalArgumentException("Unrecognized value for " + FlushMode.class.getSimpleName() + ": "
+                            + flushMode);
+        }
+
+        return msgPauseQueue.isEmpty();
+    }
+
+    protected final void flushPauseQueue(final Publisher<T> publisher) {
+        while (!paused.get() && msgPauseQueue.isEmpty()) {
+            publisher.onResume(msgPauseQueue.poll());
+        }
+    }
+
+    protected final void enqueueMessageOnPause(final T msg) {
+        if (!isPaused()) return;
+        msgPauseQueue.offer(msg);
+    }
+
+    protected interface Publisher<T> {
+
+        void onResume(T msg);
+    }
+}

--- a/src/main/java/net/engio/mbassy/bus/MBassador.java
+++ b/src/main/java/net/engio/mbassy/bus/MBassador.java
@@ -10,18 +10,16 @@ import net.engio.mbassy.bus.error.IPublicationErrorHandler;
 import net.engio.mbassy.bus.error.PublicationError;
 import net.engio.mbassy.bus.publication.SyncAsyncPostCommand;
 
-
-public class MBassador<T> extends AbstractPauseSyncAsyncMessageBus<T, SyncAsyncPostCommand<T>> implements IMessageBus<T, SyncAsyncPostCommand<T>> {
-
+public class MBassador<T> extends AbstractPauseSyncAsyncMessageBus<T, SyncAsyncPostCommand<T>>
+                      implements IMessageBus<T, SyncAsyncPostCommand<T>> {
 
     /**
      * Default constructor using default setup. super() will also add a default publication error logger
      */
-    public MBassador(){
-        this(new BusConfiguration()
-                .addFeature(Feature.SyncPubSub.Default())
-                .addFeature(Feature.AsynchronousHandlerInvocation.Default())
-                .addFeature(Feature.AsynchronousMessageDispatch.Default()));
+    public MBassador() {
+        this(new BusConfiguration().addFeature(Feature.SyncPubSub.Default())
+                                   .addFeature(Feature.AsynchronousHandlerInvocation.Default())
+                                   .addFeature(Feature.AsynchronousMessageDispatch.Default()));
     }
 
     /**
@@ -45,56 +43,48 @@ public class MBassador<T> extends AbstractPauseSyncAsyncMessageBus<T, SyncAsyncP
         super(configuration);
     }
 
-
-
-
-
     @Override
     public IMessagePublication publishAsync(final T message) {
-	final MessagePublication publication = createMessagePublication(message);
-	if (isPaused()) {
-	    super.enqueueMessageOnPause(message);
-	    return publication;
-	}
+        final MessagePublication publication = createMessagePublication(message);
+        if (isPaused()) {
+            super.enqueueMessageOnPause(message);
+            return publication;
+        }
         return addAsynchronousPublication(publication);
     }
 
     public IMessagePublication publishAsync(final T message, final long timeout, final TimeUnit unit) {
-	final MessagePublication publication = createMessagePublication(message);
-	if (isPaused()) {
-	    super.enqueueMessageOnPause(message);
-	    return publication;
-	}
+        final MessagePublication publication = createMessagePublication(message);
+        if (isPaused()) {
+            super.enqueueMessageOnPause(message);
+            return publication;
+        }
         return addAsynchronousPublication(publication, timeout, unit);
     }
 
-
     /**
-     * Synchronously publish a message to all registered listeners (this includes listeners defined for super types)
-     * The call blocks until every messageHandler has processed the message.
+     * Synchronously publish a message to all registered listeners (this includes listeners defined for super types) The
+     * call blocks until every messageHandler has processed the message.
      *
      * @param message
      */
     @Override
-    public void publish(final T message) {
-                final IMessagePublication publication = createMessagePublication(message);
-	if (isPaused()) {
-	    super.enqueueMessageOnPause(message);
-	    return publication;
-	}
+    public IMessagePublication publish(final T message) {
+        final MessagePublication publication = createMessagePublication(message);
+        if (isPaused()) {
+            super.enqueueMessageOnPause(message);
+            return publication;
+        }
         try {
             publication.execute();
         } catch (final Throwable e) {
-            handlePublicationError(new PublicationError()
-                    .setMessage("Error during publication of message")
-                    .setCause(e)
-                    .setPublication(publication));
+            handlePublicationError(new PublicationError().setMessage("Error during publication of message")
+                                                         .setCause(e)
+                                                         .setPublishedMessage(message));
         }
-        finally {
-            return publication;
-        }
-    }
 
+        return publication;
+    }
 
     @Override
     public SyncAsyncPostCommand<T> post(final T message) {

--- a/src/main/java/net/engio/mbassy/bus/MBassador.java
+++ b/src/main/java/net/engio/mbassy/bus/MBassador.java
@@ -14,12 +14,15 @@ public class MBassador<T> extends AbstractPauseSyncAsyncMessageBus<T, SyncAsyncP
                       implements IMessageBus<T, SyncAsyncPostCommand<T>> {
 
     /**
-     * Default constructor using default setup. super() will also add a default publication error logger
+     * Default constructor using default setup. super() will also add a default
+     * publication error logger
      */
     public MBassador() {
-        this(new BusConfiguration().addFeature(Feature.SyncPubSub.Default())
-                                   .addFeature(Feature.AsynchronousHandlerInvocation.Default())
-                                   .addFeature(Feature.AsynchronousMessageDispatch.Default()));
+        this(
+            new BusConfiguration()
+                .addFeature(Feature.SyncPubSub.Default())
+                .addFeature(Feature.AsynchronousHandlerInvocation.Default())
+                .addFeature(Feature.AsynchronousMessageDispatch.Default()));
     }
 
     /**
@@ -28,10 +31,12 @@ public class MBassador<T> extends AbstractPauseSyncAsyncMessageBus<T, SyncAsyncP
      * @param errorHandler
      */
     public MBassador(final IPublicationErrorHandler errorHandler) {
-        super(new BusConfiguration().addFeature(Feature.SyncPubSub.Default())
-                                    .addFeature(Feature.AsynchronousHandlerInvocation.Default())
-                                    .addFeature(Feature.AsynchronousMessageDispatch.Default())
-                                    .addPublicationErrorHandler(errorHandler));
+        super(
+            new BusConfiguration()
+                .addFeature(Feature.SyncPubSub.Default())
+                .addFeature(Feature.AsynchronousHandlerInvocation.Default())
+                .addFeature(Feature.AsynchronousMessageDispatch.Default())
+                .addPublicationErrorHandler(errorHandler));
     }
 
     /**
@@ -50,6 +55,7 @@ public class MBassador<T> extends AbstractPauseSyncAsyncMessageBus<T, SyncAsyncP
             super.enqueueMessageOnPause(message);
             return publication;
         }
+
         return addAsynchronousPublication(publication);
     }
 
@@ -59,12 +65,14 @@ public class MBassador<T> extends AbstractPauseSyncAsyncMessageBus<T, SyncAsyncP
             super.enqueueMessageOnPause(message);
             return publication;
         }
+
         return addAsynchronousPublication(publication, timeout, unit);
     }
 
     /**
-     * Synchronously publish a message to all registered listeners (this includes listeners defined for super types) The
-     * call blocks until every messageHandler has processed the message.
+     * Synchronously publish a message to all registered listeners (this
+     * includes listeners defined for super types) The call blocks until every
+     * messageHandler has processed the message.
      *
      * @param message
      */
@@ -75,12 +83,15 @@ public class MBassador<T> extends AbstractPauseSyncAsyncMessageBus<T, SyncAsyncP
             super.enqueueMessageOnPause(message);
             return publication;
         }
+
         try {
             publication.execute();
         } catch (final Throwable e) {
-            handlePublicationError(new PublicationError().setMessage("Error during publication of message")
-                                                         .setCause(e)
-                                                         .setPublishedMessage(message));
+            handlePublicationError(
+                new PublicationError()
+                    .setMessage("Error during publication of message")
+                    .setCause(e)
+                    .setPublishedMessage(message));
         }
 
         return publication;

--- a/src/main/java/net/engio/mbassy/bus/common/AsyncPubSubPauseSupport.java
+++ b/src/main/java/net/engio/mbassy/bus/common/AsyncPubSubPauseSupport.java
@@ -1,0 +1,12 @@
+package net.engio.mbassy.bus.common;
+
+
+public interface AsyncPubSubPauseSupport<T> extends PubSubPauseSupport<T> {
+
+    boolean resume(PublishMode publishMode, FlushMode flushMode);
+
+    public enum PublishMode {
+        SYNC,
+        ASYNC;
+    }
+}

--- a/src/main/java/net/engio/mbassy/bus/common/AsyncPubSubPauseSupport.java
+++ b/src/main/java/net/engio/mbassy/bus/common/AsyncPubSubPauseSupport.java
@@ -1,6 +1,11 @@
 package net.engio.mbassy.bus.common;
 
-
+/**
+ *
+ * @author Brian Groenke [groenke.5@osu.edu]
+ *
+ * @param <T>
+ */
 public interface AsyncPubSubPauseSupport<T> extends PubSubPauseSupport<T> {
 
     boolean resume(PublishMode publishMode, FlushMode flushMode);

--- a/src/main/java/net/engio/mbassy/bus/common/PubSubPauseSupport.java
+++ b/src/main/java/net/engio/mbassy/bus/common/PubSubPauseSupport.java
@@ -1,24 +1,36 @@
 package net.engio.mbassy.bus.common;
 
+/**
+ * This interface defines the necessary semantics for implementing synchronous pause/resume support in a message bus.
+ * Pause/resume allows for publication to be suspended (on calls to {@link #pause()}) from live execution until a
+ * subsequent call to {@link #resume()}. Resuming the message bus will publish all pending messages via the
+ * implementation's {@link #publish(Object)} method.
+ *
+ * @author Brian Groenke [groenke.5@osu.edu]
+ *
+ * @param <T>
+ *            the message type
+ */
 public interface PubSubPauseSupport<T> extends PubSubSupport<T> {
 
     /**
-     * Pauses event publishing. All messages submitted via
-     * {@link #publish(Object)} will be stored in a queue until
-     * {@link #resume()} is called. Any subsequent calls to this method before a
-     * call to {@link #resume()} will have no effect. Calls to this method will
-     * block until the message queue has been flushed if an atomic resume is in
+     * Pauses event publishing. All messages submitted via {@link #publish(Object)} will be stored in a queue until
+     * {@link #resume()} is called. Any subsequent calls to this method before a call to {@link #resume()} will have no
+     * effect. Calls to this method will block until the message queue has been flushed if an atomic resume is in
      * progress.
      */
     void pause();
 
     /**
-     * Resumes event publishing. All messages enqueued since the first call to
-     * {@link #pause()} will be subsequently flushed and published via
-     * {@link #publish(Object)} in the order that they arrived. Does nothing if
-     * the bus is not currently in a paused state from a call to
+     * Resumes event publishing. All messages enqueued since the first call to {@link #pause()} will be subsequently
+     * flushed and published via {@link #publish(Object)} in the order that they arrived. Atomic mode will cause all
+     * subsequent calls to <code>pause()</code> to block until all pending messages in the queue are published;
+     * non-atomic mode will flush the queue until a) another thread calls the {@link #pause()} method or b) all messages
+     * in the queue are published. This method does nothing if the bus is not currently in a paused state from a call to
      * {@link #pause()}.
      *
+     * @param flushMode
+     *            the synchronization mode to use when flushing the pause queue
      * @return true if the queue was flushed completely, false otherwise
      */
     boolean resume(FlushMode flushMode);
@@ -26,11 +38,10 @@ public interface PubSubPauseSupport<T> extends PubSubSupport<T> {
     /**
      * Equivalent to <code>resume(FlushMode.ATOMIC);</code>
      */
-    void resume();
+    boolean resume();
 
     /**
-     * @return true if this PubSubPauseSupport is currently paused, false
-     *         otherwise.
+     * @return true if this PubSubPauseSupport is currently paused, false otherwise.
      */
     boolean isPaused();
 
@@ -39,6 +50,9 @@ public interface PubSubPauseSupport<T> extends PubSubSupport<T> {
      */
     int countInQueue();
 
+    /**
+     * FlushMode defines the flushing behavior of the <code>resume(FlushMode)</code> method.
+     */
     public enum FlushMode {
         ATOMIC,
         NONATOMIC;

--- a/src/main/java/net/engio/mbassy/bus/common/PubSubPauseSupport.java
+++ b/src/main/java/net/engio/mbassy/bus/common/PubSubPauseSupport.java
@@ -1,0 +1,46 @@
+package net.engio.mbassy.bus.common;
+
+public interface PubSubPauseSupport<T> extends PubSubSupport<T> {
+
+    /**
+     * Pauses event publishing. All messages submitted via
+     * {@link #publish(Object)} will be stored in a queue until
+     * {@link #resume()} is called. Any subsequent calls to this method before a
+     * call to {@link #resume()} will have no effect. Calls to this method will
+     * block until the message queue has been flushed if an atomic resume is in
+     * progress.
+     */
+    void pause();
+
+    /**
+     * Resumes event publishing. All messages enqueued since the first call to
+     * {@link #pause()} will be subsequently flushed and published via
+     * {@link #publish(Object)} in the order that they arrived. Does nothing if
+     * the bus is not currently in a paused state from a call to
+     * {@link #pause()}.
+     *
+     * @return true if the queue was flushed completely, false otherwise
+     */
+    boolean resume(FlushMode flushMode);
+
+    /**
+     * Equivalent to <code>resume(FlushMode.ATOMIC);</code>
+     */
+    void resume();
+
+    /**
+     * @return true if this PubSubPauseSupport is currently paused, false
+     *         otherwise.
+     */
+    boolean isPaused();
+
+    /**
+     * @return the number of messages currently waiting in the pause queue
+     */
+    int countInQueue();
+
+    public enum FlushMode {
+        ATOMIC,
+        NONATOMIC;
+    }
+}

--- a/src/test/java/net/engio/mbassy/AllTests.java
+++ b/src/test/java/net/engio/mbassy/AllTests.java
@@ -18,6 +18,7 @@ import org.junit.runners.Suite;
         FilterTest.class,
         MetadataReaderTest.class,
         MethodDispatchTest.class,
+        PubSubPauseSupportTest.class,
         StrongConcurrentSetTest.class,
         SubscriptionManagerTest.class,
         SyncAsyncTest.class,

--- a/src/test/java/net/engio/mbassy/PubSubPauseSupportTest.java
+++ b/src/test/java/net/engio/mbassy/PubSubPauseSupportTest.java
@@ -1,0 +1,106 @@
+package net.engio.mbassy;
+
+import net.engio.mbassy.bus.MBassador;
+import net.engio.mbassy.bus.publication.SyncAsyncPostCommand;
+import net.engio.mbassy.common.ConcurrentExecutor;
+import net.engio.mbassy.common.ListenerFactory;
+import net.engio.mbassy.common.MessageBusTest;
+import net.engio.mbassy.listeners.IMessageListener;
+import net.engio.mbassy.listeners.Listeners;
+import net.engio.mbassy.listeners.MessagesTypeListener;
+import net.engio.mbassy.messages.MessageTypes;
+import net.engio.mbassy.messages.MultipartMessage;
+import net.engio.mbassy.messages.StandardMessage;
+
+import org.junit.After;
+import org.junit.Test;
+
+public class PubSubPauseSupportTest extends MessageBusTest {
+
+    private MBassador bus;
+
+    @After
+    public void tearDown ()
+    {
+	if (bus != null) bus.shutdown();
+        bus.shutdown();
+        pause(200);
+    }
+
+    @Test
+    public void testSyncWithSyncHandlersUnpausedPublication ()
+    {
+        final ListenerFactory listeners = new ListenerFactory()
+                .create(InstancesPerListener, Listeners.synchronous())
+                .create(InstancesPerListener, Listeners.noHandlers());
+        bus = createBus (SyncAsync (), listeners);
+
+        final Runnable publishAndCheck = new Runnable() {
+            @Override
+            public void run() {
+                final StandardMessage standardMessage = new StandardMessage();
+                final MultipartMessage multipartMessage = new MultipartMessage();
+
+                bus.post(standardMessage).now();
+                bus.post(multipartMessage).now();
+                bus.post(MessageTypes.Simple).now();
+
+                assertEquals(InstancesPerListener, standardMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+                assertEquals(InstancesPerListener, multipartMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+            }
+        };
+
+        // test single-threaded
+        ConcurrentExecutor.runConcurrent(publishAndCheck, 1);
+
+        // test multi-threaded
+        MessageTypes.resetAll();
+        ConcurrentExecutor.runConcurrent(publishAndCheck, ConcurrentUnits);
+        assertEquals(InstancesPerListener * ConcurrentUnits, MessageTypes.Simple.getTimesHandled(IMessageListener.DefaultListener.class));
+        assertEquals(InstancesPerListener * ConcurrentUnits, MessageTypes.Simple.getTimesHandled(MessagesTypeListener.DefaultListener.class));
+    }
+
+    @Test
+    public void testSyncWithSyncHandlersPauseAndResumePublication ()
+    {
+	final ListenerFactory listeners = new ListenerFactory()
+		.create(InstancesPerListener, Listeners.synchronous())
+		.create(InstancesPerListener, Listeners.noHandlers());
+	bus = createBus (SyncAsync (), listeners);
+
+	final Runnable publishAndCheck = new Runnable() {
+	    @Override
+	    public void run() {
+		final StandardMessage standardMessage = new StandardMessage();
+		final MultipartMessage multipartMessage = new MultipartMessage();
+
+		final SyncAsyncPostCommand stdmsg = bus.post(standardMessage);
+		final SyncAsyncPostCommand mpmsg = bus.post(multipartMessage);
+		final SyncAsyncPostCommand smsg = bus.post(MessageTypes.Simple);
+
+		bus.pause();
+
+		stdmsg.now();
+		mpmsg.now();
+		smsg.now();
+
+		assertEquals(0, standardMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+		assertEquals(0, multipartMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+
+		bus.resume();
+
+                assertEquals(InstancesPerListener, standardMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+                assertEquals(InstancesPerListener, multipartMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+	    }
+	};
+
+	// test single-threaded
+	ConcurrentExecutor.runConcurrent(publishAndCheck, 1);
+
+	// test multi-threaded
+	MessageTypes.resetAll();
+	ConcurrentExecutor.runConcurrent(publishAndCheck, ConcurrentUnits);
+	assertEquals(InstancesPerListener * ConcurrentUnits, MessageTypes.Simple.getTimesHandled(IMessageListener.DefaultListener.class));
+	assertEquals(InstancesPerListener * ConcurrentUnits, MessageTypes.Simple.getTimesHandled(MessagesTypeListener.DefaultListener.class));
+    }
+}

--- a/src/test/java/net/engio/mbassy/PubSubPauseSupportTest.java
+++ b/src/test/java/net/engio/mbassy/PubSubPauseSupportTest.java
@@ -1,11 +1,16 @@
 package net.engio.mbassy;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import net.engio.mbassy.bus.MBassador;
+import net.engio.mbassy.bus.common.PubSubPauseSupport.FlushMode;
 import net.engio.mbassy.bus.publication.SyncAsyncPostCommand;
 import net.engio.mbassy.common.ConcurrentExecutor;
 import net.engio.mbassy.common.ListenerFactory;
 import net.engio.mbassy.common.MessageBusTest;
+import net.engio.mbassy.common.MessageManager;
 import net.engio.mbassy.listeners.IMessageListener;
+import net.engio.mbassy.listeners.IMultipartMessageListener;
 import net.engio.mbassy.listeners.Listeners;
 import net.engio.mbassy.listeners.MessagesTypeListener;
 import net.engio.mbassy.messages.MessageTypes;
@@ -15,27 +20,33 @@ import net.engio.mbassy.messages.StandardMessage;
 import org.junit.After;
 import org.junit.Test;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Brian Groenke [groenke.5@osu.edu]
+ */
 public class PubSubPauseSupportTest extends MessageBusTest {
+
+    private static final Logger log = LoggerFactory.getLogger(PubSubPauseSupportTest.class);
 
     private MBassador bus;
 
     @After
-    public void tearDown ()
-    {
-	if (bus != null) bus.shutdown();
+    public void tearDown() {
+        if (bus != null) bus.shutdown();
         bus.shutdown();
         pause(200);
     }
 
     @Test
-    public void testSyncWithSyncHandlersUnpausedPublication ()
-    {
-        final ListenerFactory listeners = new ListenerFactory()
-                .create(InstancesPerListener, Listeners.synchronous())
-                .create(InstancesPerListener, Listeners.noHandlers());
-        bus = createBus (SyncAsync (), listeners);
+    public void testUnpausedPublicationWithSyncHandlers() {
+        final ListenerFactory listeners = new ListenerFactory().create(InstancesPerListener, Listeners.synchronous())
+                                                               .create(InstancesPerListener, Listeners.noHandlers());
+        bus = createBus(SyncAsync(), listeners);
 
         final Runnable publishAndCheck = new Runnable() {
+
             @Override
             public void run() {
                 final StandardMessage standardMessage = new StandardMessage();
@@ -45,8 +56,10 @@ public class PubSubPauseSupportTest extends MessageBusTest {
                 bus.post(multipartMessage).now();
                 bus.post(MessageTypes.Simple).now();
 
-                assertEquals(InstancesPerListener, standardMessage.getTimesHandled(IMessageListener.DefaultListener.class));
-                assertEquals(InstancesPerListener, multipartMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+                assertEquals(InstancesPerListener,
+                             standardMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+                assertEquals(InstancesPerListener,
+                             multipartMessage.getTimesHandled(IMessageListener.DefaultListener.class));
             }
         };
 
@@ -56,51 +69,158 @@ public class PubSubPauseSupportTest extends MessageBusTest {
         // test multi-threaded
         MessageTypes.resetAll();
         ConcurrentExecutor.runConcurrent(publishAndCheck, ConcurrentUnits);
-        assertEquals(InstancesPerListener * ConcurrentUnits, MessageTypes.Simple.getTimesHandled(IMessageListener.DefaultListener.class));
-        assertEquals(InstancesPerListener * ConcurrentUnits, MessageTypes.Simple.getTimesHandled(MessagesTypeListener.DefaultListener.class));
+        assertEquals(InstancesPerListener * ConcurrentUnits,
+                     MessageTypes.Simple.getTimesHandled(IMessageListener.DefaultListener.class));
+        assertEquals(InstancesPerListener * ConcurrentUnits,
+                     MessageTypes.Simple.getTimesHandled(MessagesTypeListener.DefaultListener.class));
     }
 
     @Test
-    public void testSyncWithSyncHandlersPauseAndResumePublication ()
-    {
-	final ListenerFactory listeners = new ListenerFactory()
-		.create(InstancesPerListener, Listeners.synchronous())
-		.create(InstancesPerListener, Listeners.noHandlers());
-	bus = createBus (SyncAsync (), listeners);
+    public void testPauseAtomicResumePublicationWithSyncHandlers() {
+        final ListenerFactory listeners = new ListenerFactory().create(InstancesPerListener, Listeners.synchronous())
+                                                               .create(InstancesPerListener, Listeners.noHandlers());
+        bus = createBus(SyncAsync(), listeners);
 
-	final Runnable publishAndCheck = new Runnable() {
-	    @Override
-	    public void run() {
-		final StandardMessage standardMessage = new StandardMessage();
-		final MultipartMessage multipartMessage = new MultipartMessage();
+        final Runnable publishAndCheck = new Runnable() {
 
-		final SyncAsyncPostCommand stdmsg = bus.post(standardMessage);
-		final SyncAsyncPostCommand mpmsg = bus.post(multipartMessage);
-		final SyncAsyncPostCommand smsg = bus.post(MessageTypes.Simple);
+            @Override
+            public void run() {
+                final StandardMessage standardMessage = new StandardMessage();
+                final MultipartMessage multipartMessage = new MultipartMessage();
 
-		bus.pause();
+                final SyncAsyncPostCommand stdmsg = bus.post(standardMessage);
+                final SyncAsyncPostCommand mpmsg = bus.post(multipartMessage);
+                final SyncAsyncPostCommand smsg = bus.post(MessageTypes.Simple);
 
-		stdmsg.now();
-		mpmsg.now();
-		smsg.now();
+                synchronized (bus) {
+                    bus.pause();
 
-		assertEquals(0, standardMessage.getTimesHandled(IMessageListener.DefaultListener.class));
-		assertEquals(0, multipartMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+                    stdmsg.now();
+                    mpmsg.now();
+                    smsg.now();
 
-		bus.resume();
+                    assertEquals(0, standardMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+                    assertEquals(0, multipartMessage.getTimesHandled(IMessageListener.DefaultListener.class));
 
-                assertEquals(InstancesPerListener, standardMessage.getTimesHandled(IMessageListener.DefaultListener.class));
-                assertEquals(InstancesPerListener, multipartMessage.getTimesHandled(IMessageListener.DefaultListener.class));
-	    }
-	};
+                    assertTrue(bus.resume()); // synchronous/atomic resume
+                }
 
-	// test single-threaded
-	ConcurrentExecutor.runConcurrent(publishAndCheck, 1);
+                assertEquals(InstancesPerListener,
+                             standardMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+                assertEquals(InstancesPerListener,
+                             multipartMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+            }
+        };
 
-	// test multi-threaded
-	MessageTypes.resetAll();
-	ConcurrentExecutor.runConcurrent(publishAndCheck, ConcurrentUnits);
-	assertEquals(InstancesPerListener * ConcurrentUnits, MessageTypes.Simple.getTimesHandled(IMessageListener.DefaultListener.class));
-	assertEquals(InstancesPerListener * ConcurrentUnits, MessageTypes.Simple.getTimesHandled(MessagesTypeListener.DefaultListener.class));
+        // test single-threaded
+        ConcurrentExecutor.runConcurrent(publishAndCheck, 1);
+
+        // test multi-threaded
+        MessageTypes.resetAll();
+        ConcurrentExecutor.runConcurrent(publishAndCheck, ConcurrentUnits);
+        assertEquals(InstancesPerListener * ConcurrentUnits,
+                     MessageTypes.Simple.getTimesHandled(IMessageListener.DefaultListener.class));
+        assertEquals(InstancesPerListener * ConcurrentUnits,
+                     MessageTypes.Simple.getTimesHandled(MessagesTypeListener.DefaultListener.class));
+    }
+
+    @Test
+    public void testPauseNonatomicResumePublicationWithSyncHandlers() {
+        final ListenerFactory listeners = new ListenerFactory().create(InstancesPerListener, Listeners.synchronous())
+                                                               .create(InstancesPerListener, Listeners.noHandlers());
+        bus = createBus(SyncAsync(), listeners);
+
+        final Runnable publishAndCheck = new Runnable() {
+
+            @Override
+            public void run() {
+                final StandardMessage standardMessage = new StandardMessage();
+                final MultipartMessage multipartMessage = new MultipartMessage();
+
+                final SyncAsyncPostCommand stdmsg = bus.post(standardMessage);
+                final SyncAsyncPostCommand mpmsg = bus.post(multipartMessage);
+                final SyncAsyncPostCommand smsg = bus.post(MessageTypes.Simple);
+
+                final int numLeftInQueue;
+                synchronized (bus) {
+                    bus.pause();
+
+                    stdmsg.now();
+                    mpmsg.now();
+                    smsg.now();
+
+                    assertEquals(0, standardMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+                    assertEquals(0, multipartMessage.getTimesHandled(IMessageListener.DefaultListener.class));
+
+                    bus.resume(FlushMode.NONATOMIC);
+                    numLeftInQueue = bus.countInQueue();
+                }
+
+                // With nonatomic resume, some messages may or may not still be in the queue; so we need to check
+                // that at least as many messages were published as there are handlers minus the outstanding queue size.
+                final int handleCountLowerBound = Math.max(InstancesPerListener - numLeftInQueue, 0);
+                assertTrue(standardMessage.getTimesHandled(IMessageListener.DefaultListener.class) >= handleCountLowerBound);
+                assertTrue(multipartMessage.getTimesHandled(IMessageListener.DefaultListener.class) >= handleCountLowerBound);
+            }
+        };
+
+        // test single-threaded
+        ConcurrentExecutor.runConcurrent(publishAndCheck, 1);
+
+        // test multi-threaded
+        MessageTypes.resetAll();
+        ConcurrentExecutor.runConcurrent(publishAndCheck, ConcurrentUnits);
+        assertEquals(InstancesPerListener * ConcurrentUnits,
+                     MessageTypes.Simple.getTimesHandled(IMessageListener.DefaultListener.class));
+        assertEquals(InstancesPerListener * ConcurrentUnits,
+                     MessageTypes.Simple.getTimesHandled(MessagesTypeListener.DefaultListener.class));
+    }
+
+    @Test
+    public void testPauseAtomicResumePublicationWithAsyncHandlers() {
+        final ListenerFactory listeners = new ListenerFactory().create(InstancesPerListener, Listeners.asynchronous())
+                                                               .create(InstancesPerListener, Listeners.noHandlers());
+        bus = createBus(SyncAsync(), listeners);
+
+        final MessageManager messageManager = new MessageManager();
+        final AtomicInteger expectedCount = new AtomicInteger(0);
+        final Runnable publish = new Runnable() {
+            @Override
+            public void run() {
+
+                final StandardMessage standardMessage = messageManager.createAndTrack(
+                        StandardMessage.class,
+                        expectedCount.get(),
+                        Listeners.join(Listeners.asynchronous(),Listeners.handlesStandardMessage()));
+                final MultipartMessage multipartMessage = messageManager.create(
+                        MultipartMessage.class,
+                        expectedCount.get(),
+                        IMessageListener.AsyncListener.class, IMultipartMessageListener.AsyncListener.class);
+
+                bus.post(standardMessage).now();
+                bus.post(multipartMessage).now();
+                bus.post(MessageTypes.Simple).now();
+            }
+        };
+
+        bus.pause();
+        ConcurrentExecutor.runConcurrent(publish, 1);
+        messageManager.waitForMessages(waitForMessageTimeout);
+        expectedCount.set(InstancesPerListener);
+        ConcurrentExecutor.runConcurrent(publish, 1);
+        bus.resume();
+        messageManager.waitForMessages(waitForMessageTimeout);
+
+        MessageTypes.resetAll();
+        messageManager.register(MessageTypes.Simple, 0, IMessageListener.AsyncListener.class, MessagesTypeListener.AsyncListener.class);
+        expectedCount.set(0);
+        bus.pause();
+        ConcurrentExecutor.runConcurrent(publish, ConcurrentUnits);
+        messageManager.waitForMessages(waitForMessageTimeout);
+
+        messageManager.register(MessageTypes.Simple, InstancesPerListener * ConcurrentUnits, IMessageListener.AsyncListener.class, MessagesTypeListener.AsyncListener.class);
+        expectedCount.set(InstancesPerListener);
+        bus.resume();
+        messageManager.waitForMessages(waitForMessageTimeout);
     }
 }


### PR DESCRIPTION
See PubSubPauseSupport javadoc comments for API documentation.

Notes on resume() methods:
PubSubPauseSupport.resume() takes a single parameter, an enum type FlushMode that determines the behavior or subsequent calls to pause while the queue flush is in progress. The default setting is FlushMode.ATOMIC, which will engage a lock that causes calls to 'pause()' to block until resume returns. FlushMode.NONATOMIC will cause 'resume()' to flush until either the queue is empty OR 'pause()' is called again.

AsyncPubSubPauseSupport defines another enum PublishMode which differentiates between synchronous or asynchronous publishing of events on resume. The class is implemented by AbstractPauseSyncAsyncMessageBus (subclass of pre-existing AbstractSyncAsyncMessageBus) from which MBassador now inherits.
