### PR TITLE
squid:S1213 -  The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/net/engio/mbassy/bus/config/Feature.java
+++ b/src/main/java/net/engio/mbassy/bus/config/Feature.java
@@ -21,6 +21,11 @@ public interface Feature {
 
     class SyncPubSub implements Feature{
 
+        private MessagePublication.Factory publicationFactory;
+        private MetadataReader metadataReader;
+        private SubscriptionFactory subscriptionFactory;
+        private ISubscriptionManagerProvider subscriptionManagerProvider;
+
         public static final SyncPubSub Default(){
             return new SyncPubSub()
                     .setMetadataReader(new MetadataReader())
@@ -28,11 +33,6 @@ public interface Feature {
                     .setSubscriptionFactory(new SubscriptionFactory())
                     .setSubscriptionManagerProvider(new SubscriptionManagerProvider());
         }
-
-        private MessagePublication.Factory publicationFactory;
-        private MetadataReader metadataReader;
-        private SubscriptionFactory subscriptionFactory;
-        private ISubscriptionManagerProvider subscriptionManagerProvider;
 
         public ISubscriptionManagerProvider getSubscriptionManagerProvider() {
             return subscriptionManagerProvider;
@@ -90,6 +90,7 @@ public interface Feature {
                 return thread;
             }
         };
+        private ExecutorService executor;
 
         public static final AsynchronousHandlerInvocation Default(){
             int numberOfCores = Runtime.getRuntime().availableProcessors();
@@ -100,8 +101,6 @@ public interface Feature {
             return new AsynchronousHandlerInvocation().setExecutor(new ThreadPoolExecutor(minThreadCount, maxThreadCount, 1,
                     TimeUnit.MINUTES, new LinkedBlockingQueue<Runnable>(), MessageHandlerThreadFactory));
         }
-
-        private ExecutorService executor;
 
         public ExecutorService getExecutor() {
             return executor;
@@ -127,6 +126,9 @@ public interface Feature {
                 return thread;
             }
         };
+        private int numberOfMessageDispatchers;
+        private BlockingQueue<IMessagePublication> messageQueue;
+        private ThreadFactory dispatcherThreadFactory;
 
         public static final AsynchronousMessageDispatch Default(){
             return new AsynchronousMessageDispatch()
@@ -134,11 +136,6 @@ public interface Feature {
                 .setDispatcherThreadFactory(MessageDispatchThreadFactory)
                 .setMessageQueue(new LinkedBlockingQueue<IMessagePublication>(Integer.MAX_VALUE));
         }
-
-
-        private int numberOfMessageDispatchers;
-        private BlockingQueue<IMessagePublication> messageQueue;
-        private ThreadFactory dispatcherThreadFactory;
 
         public int getNumberOfMessageDispatchers() {
             return numberOfMessageDispatchers;

--- a/src/main/java/net/engio/mbassy/listener/MessageListener.java
+++ b/src/main/java/net/engio/mbassy/listener/MessageListener.java
@@ -26,6 +26,17 @@ import java.util.List;
 public class MessageListener<T> {
 
 
+    private ArrayList<MessageHandler> handlers = new ArrayList<MessageHandler>();
+
+    private Class<T> listenerDefinition;
+
+    private Listener listenerAnnotation;
+
+    public MessageListener(Class<T> listenerDefinition) {
+        this.listenerDefinition = listenerDefinition;
+        listenerAnnotation = ReflectionUtils.getAnnotation( listenerDefinition, Listener.class );
+    }
+
     public static IPredicate<MessageHandler> ForMessage(final Class<?> messageType) {
         return new IPredicate<MessageHandler>() {
             @Override
@@ -34,18 +45,6 @@ public class MessageListener<T> {
             }
         };
     }
-
-    private ArrayList<MessageHandler> handlers = new ArrayList<MessageHandler>();
-
-    private Class<T> listenerDefinition;
-
-    private Listener listenerAnnotation;
-
-    public MessageListener(Class<T> listenerDefinition) {
-       this.listenerDefinition = listenerDefinition;
-       listenerAnnotation = ReflectionUtils.getAnnotation( listenerDefinition, Listener.class );
-    }
-
 
     public boolean isFromListener(Class listener){
         return listenerDefinition.equals(listener);

--- a/src/main/java/net/engio/mbassy/subscription/Subscription.java
+++ b/src/main/java/net/engio/mbassy/subscription/Subscription.java
@@ -23,6 +23,14 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class Subscription {
 
+    public static final Comparator<Subscription> SubscriptionByPriorityDesc = new Comparator<Subscription>() {
+        @Override
+        public int compare(Subscription o1, Subscription o2) {
+            int byPriority = ((Integer)o2.getPriority()).compareTo(o1.getPriority());
+            return byPriority == 0 ? o2.id.compareTo(o1.id) : byPriority;
+        }
+    };
+
     private final UUID id = UUID.randomUUID();
 
     protected final Collection<Object> listeners;
@@ -95,14 +103,6 @@ public class Subscription {
     public Handle getHandle(){
         return new Handle();
     }
-
-    public static final Comparator<Subscription> SubscriptionByPriorityDesc = new Comparator<Subscription>() {
-        @Override
-        public int compare(Subscription o1, Subscription o2) {
-            int byPriority = ((Integer)o2.getPriority()).compareTo(o1.getPriority());
-            return byPriority == 0 ? o2.id.compareTo(o1.id) : byPriority;
-        }
-    };
 
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava