### PR TITLE
squid:S1118 -  Utility classes should not have public constructors

### DIFF
--- a/src/main/java/net/engio/mbassy/bus/config/IBusConfiguration.java
+++ b/src/main/java/net/engio/mbassy/bus/config/IBusConfiguration.java
@@ -86,5 +86,6 @@ public interface IBusConfiguration{
         public static final String PublicationErrorHandlers = "bus.handlers.error";
         public static final String AsynchronousHandlerExecutor = "bus.handlers.async-executor";
 
+        private Properties() {}
     }
 }

--- a/src/main/java/net/engio/mbassy/common/ReflectionUtils.java
+++ b/src/main/java/net/engio/mbassy/common/ReflectionUtils.java
@@ -15,6 +15,8 @@ import java.util.Set;
  */
 public class ReflectionUtils
 {
+    private ReflectionUtils() {}
+
     public static Method[] getMethods(IPredicate<Method> condition, Class<?> target) {
         ArrayList<Method> methods = new ArrayList<Method>();
 

--- a/src/main/java/net/engio/mbassy/dispatch/el/ElFilter.java
+++ b/src/main/java/net/engio/mbassy/dispatch/el/ElFilter.java
@@ -22,6 +22,8 @@ public class ElFilter implements IMessageFilter {
         // if runtime exception is thrown, this will
         public static final ExpressionFactory ELFactory = getELFactory();
 
+        private ExpressionFactoryHolder() {}
+
         /**
          * **********************************************************************
          * Get an implementation of the ExpressionFactory. This uses the

--- a/src/main/java/net/engio/mbassy/listener/Filters.java
+++ b/src/main/java/net/engio/mbassy/listener/Filters.java
@@ -11,6 +11,7 @@ import net.engio.mbassy.subscription.SubscriptionContext;
 public class Filters {
 
 
+    private Filters() {}
 
     /**
      * This filter will only accept messages of the exact same type

--- a/src/main/java/net/engio/mbassy/listener/MessageHandler.java
+++ b/src/main/java/net/engio/mbassy/listener/MessageHandler.java
@@ -33,6 +33,8 @@ public class MessageHandler {
         public static final String Priority = "priority";
         public static final String Invocation = "invocation";
 
+        private Properties() {}
+
         /**
          * Create the property map for the {@link MessageHandler} constructor using the default objects.
          *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava