### PR TITLE
Add a new way to define filters for handler methods

### DIFF
--- a/src/main/java/net/engio/mbassy/listener/RepeatedFilters.java
+++ b/src/main/java/net/engio/mbassy/listener/RepeatedFilters.java
@@ -1,0 +1,23 @@
+package net.engio.mbassy.listener;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The repeated filters annotation is used to add multiple {@link Filter}s to
+ * a single {@link ElementType#ANNOTATION_TYPE annotation type} when using
+ * "inherited filters".
+ *
+ * @see Filter
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface RepeatedFilters {
+
+    /**
+     * An array of filters to be used for filtering {@link Handler}s.
+     */
+    Filter[] value();
+}

--- a/src/test/java/net/engio/mbassy/FilterTest.java
+++ b/src/test/java/net/engio/mbassy/FilterTest.java
@@ -12,6 +12,8 @@ import net.engio.mbassy.messages.TestMessage;
 import net.engio.mbassy.subscription.SubscriptionContext;
 import org.junit.Test;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -82,13 +84,15 @@ public class FilterTest extends MessageBusTest {
         }
 
         // FilteredEvents that contain messages of class Object will be filtered (again) and should cause a DeadEvent to be thrown
-        @Handler(filters = {@Filter(RejectFilteredObjects.class)})
+        @Handler
+        @RejectFilteredObjectsFilter
         public void handleFilteredEvent(FilteredMessage filtered){
             FilteredEventCounter.incrementAndGet();
         }
 
         // will cause republication of a FilteredEvent
-        @Handler(filters = {@Filter(RejectAll.class)})
+        @Handler
+        @RejectAllFilter
         public void handleNone(Object any){
             FilteredEventCounter.incrementAndGet();
         }
@@ -146,6 +150,18 @@ public class FilterTest extends MessageBusTest {
         public boolean accepts(Object event,  SubscriptionContext context) {
             return false;
         }
+    }
+
+    @Filter(RejectFilteredObjects.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface RejectFilteredObjectsFilter {
+
+    }
+
+    @RepeatedFilters({@Filter(RejectAll.class)})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface RejectAllFilter {
+
     }
 
 }


### PR DESCRIPTION
Using the `filters` attribute on Handler works fine, but results in a lot of repetition. This adds a way to avoid this, by introducing a way to define Filters on an annotation type.