### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
+arch:
+ - amd
+ - ppc64le
+ 
 jdk:
-  - openjdk7
+  - openjdk11
 script:
   mvn clean test


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and updated the jdk version because it supports higher jdk version between 9 and 15, and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/mbassador/builds/201720052

Please have a look.

Regards,